### PR TITLE
avoid re-downloading existing files

### DIFF
--- a/tasks/nextcloud/download.yml
+++ b/tasks/nextcloud/download.yml
@@ -15,7 +15,7 @@
 - block:
     - name: "Nextcloud download: fetch version tarball and signature"
       get_url:
-        dest: "{{ nextcloud_dl_tmp_dir }}"
+        dest: "{{ nextcloud_dl_tmp_dir }}/{{ item | basename }}"
         url: "{{ item }}"
       with_items:
         - "{{ nextcloud_tar_url }}"


### PR DESCRIPTION
from get_url ansible doc

> If dest is a directory, the file will always be downloaded

so changing the dest into a file name will avoid re-downloading the files