### PR TITLE
Harden notify push service to be more robust and start after boot

### DIFF
--- a/tasks/nextcloud/notify-push.yml
+++ b/tasks/nextcloud/notify-push.yml
@@ -34,6 +34,7 @@
     service:
       name: nextcloud-notify-push
       state: started
+      daemon_reload: yes
       enabled: yes
 
   - name: install and enable Nextcloud app notify_push

--- a/templates/systemd/nextcloud-notify-push.service.j2
+++ b/templates/systemd/nextcloud-notify-push.service.j2
@@ -1,11 +1,15 @@
 [Unit]
-Description = Push daemon for Nextcloud clients
+Description=Push daemon for Nextcloud clients
+After=network-online.target
 
 [Service]
-Environment = {%if nextcloud_notify_push_bind|default(False) %}BIND={{ nextcloud_notify_push_bind }}{% endif %} PORT={{ nextcloud_notify_push_port }} {% if nextcloud_notify_push_metrics_port|default(False) %}METRICS_PORT={{ nextcloud_notify_push_metrics_port }}{% endif %}
+Environment={%if nextcloud_notify_push_bind|default(False) %}BIND={{ nextcloud_notify_push_bind }}{% endif %} PORT={{ nextcloud_notify_push_port }} {% if nextcloud_notify_push_metrics_port|default(False) %}METRICS_PORT={{ nextcloud_notify_push_metrics_port }}{% endif %}
 
-ExecStart = /usr/local/bin/notify_push {{ nextcloud_instance }}/config/config.php
+ExecStart=/usr/local/bin/notify_push {{ nextcloud_instance }}/config/config.php
 User={{ nextcloud_http_user }}
 
+Restart=on-failure
+RestartSec=30s
+
 [Install]
-WantedBy = multi-user.target
+WantedBy=multi-user.target


### PR DESCRIPTION
* ensure the service is started after the network and 30s of sleep
https://github.com/nextcloud/notify_push/issues/125

* ensure the service is restarted on failure