### PR TITLE
Custom apps support

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -91,6 +91,11 @@ nextcloud_admin_user: admin
 nextcloud_www_alias: yes
 nextcloud_www_alias_name: "nextcloud"
 
+# List of Nextcloud (custom) Apps which should be copied from nextcloud/apps/ to
+# the instance apps directory. The apps then need to be enabled by also adding
+# them to nextcloud_apps.
+nextcloud_custom_apps: []
+
 # List of Nextcloud Apps to install/enable
 nextcloud_apps: []
 

--- a/tasks/nextcloud/configure.yml
+++ b/tasks/nextcloud/configure.yml
@@ -24,6 +24,17 @@
     directory_mode: 0750
   when: nextcloud_config.system.theme is defined
 
+- name: "Nextcloud configure: copy custom apps"
+  ansible.builtin.copy:
+    src: "nextcloud/apps/{{ item }}"
+    dest: "{{ __nextcloud_install_dir }}/apps/"
+    owner: "{{ nextcloud_http_user }}"
+    group: "{{ nextcloud_http_group }}"
+    mode: 0640
+    directory_mode: 0750
+  with_items:
+    - "{{ nextcloud_custom_apps }}"
+
 - name: "Nextcloud configure: get global preferences"
   ansible.builtin.command: php occ config:list --private --output=json
   args:


### PR DESCRIPTION
"Custom" apps are self-written apps which are not hosted in the nextcloud registry. Therefore, to install them they need to be added to the nextcloud instance's apps directory.

This MR adds an array `nextcloud_custom_apps` – the values represent directories within the `nextcloud/apps/` file search path. They are copied to the `/apps` directory of the nextcloud instance.

The custom apps also need to be added to `nextcloud_apps` in order for them to be enabled.