### PR TITLE
Fix broken upgrade process using custom apps

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -93,8 +93,7 @@ nextcloud_www_alias: yes
 nextcloud_www_alias_name: "nextcloud"
 
 # List of Nextcloud (custom) Apps which should be copied from nextcloud/apps/ to
-# the instance apps directory. The apps then need to be enabled by also adding
-# them to nextcloud_apps.
+# the instance apps directory and enabled in nextcloud.
 nextcloud_custom_apps: []
 
 # List of Nextcloud Apps to install/enable

--- a/tasks/nextcloud/configure.yml
+++ b/tasks/nextcloud/configure.yml
@@ -35,6 +35,19 @@
   with_items:
     - "{{ nextcloud_custom_apps }}"
 
+- name: "Nextcloud configure: enable custom apps"
+  become: true
+  become_user: "{{ nextcloud_http_user }}"
+  nextcloud_app:
+    name: "{{ item }}"
+    nextcloud_path: "{{ __nextcloud_install_dir }}"
+    state: "enabled"
+  register: __nextcloud_app_installed
+  retries: 3
+  delay: 3
+  until: __nextcloud_app_installed is not failed
+  with_items: "{{ nextcloud_custom_apps }}"
+
 - name: "Nextcloud configure: get global preferences"
   ansible.builtin.command: php occ config:list --private --output=json
   args:


### PR DESCRIPTION
The custom apps functionality was previously broken when upgrading:

The apps taskfile which was also used to enable custom apps was run in the upgrade taskfile which meant that the custom app was not found at this point.

The change in logic is thus: enable only the custom apps after they were copied. Custom apps should no longer be listed in the `nextcloud_apps` var.

Another possible solution would be to move the copying of the custom apps into the apps taskfile. TBH I don't quite understand enough of how all this works to get this to work.