### PR TITLE
feat: Allow configuring max_connection_time for notify_push

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -163,6 +163,7 @@ nextcloud_notify_push: False
 nextcloud_notify_push_version: "latest"
 nextcloud_notify_push_url: "https://github.com/nextcloud/notify_push/releases/download/v{{ nextcloud_notify_push_version }}/notify_push-x86_64-unknown-linux-musl"
 nextcloud_notify_push_allow_self_signed: False
+nextcloud_notify_push_max_connection_time: False
 
 # Uncomment to bind Nextcloud notify_push daemon to localhost
 # nextcloud_notify_push_bind: 127.0.0.1

--- a/templates/systemd/nextcloud-notify-push.service.j2
+++ b/templates/systemd/nextcloud-notify-push.service.j2
@@ -3,7 +3,7 @@ Description=Push daemon for Nextcloud clients
 After=network-online.target
 
 [Service]
-Environment={%if nextcloud_notify_push_bind|default(False) %}BIND={{ nextcloud_notify_push_bind }}{% endif %} PORT={{ nextcloud_notify_push_port }} {% if nextcloud_notify_push_metrics_port|default(False) %}METRICS_PORT={{ nextcloud_notify_push_metrics_port }}{% endif %} {%if nextcloud_notify_push_allow_self_signed|default(False) %}ALLOW_SELF_SIGNED=true{% endif %}
+Environment={%if nextcloud_notify_push_bind|default(False) %}BIND={{ nextcloud_notify_push_bind }}{% endif %} PORT={{ nextcloud_notify_push_port }} {% if nextcloud_notify_push_metrics_port|default(False) %}METRICS_PORT={{ nextcloud_notify_push_metrics_port }}{% endif %} {%if nextcloud_notify_push_allow_self_signed|default(False) %}ALLOW_SELF_SIGNED=true{% endif %} {%if nextcloud_notify_push_max_connection_time|default(False) %}MAX_CONNECTION_TIME={{ nextcloud_notify_push_max_connection_time }}{% endif %}
 
 ExecStart=/usr/local/bin/notify_push {{ nextcloud_instance }}/config/config.php
 User={{ nextcloud_http_user }}


### PR DESCRIPTION
This allows to configure the maximum connection time of the notify_push service which was introduced in https://github.com/nextcloud/notify_push/pull/282