### PR TITLE
Nextcloud Apps API: bump delay between each GET attempt

### DIFF
--- a/tasks/nextcloud/apps.yml
+++ b/tasks/nextcloud/apps.yml
@@ -9,7 +9,7 @@
     state: "{{ nextcloud_apps_upgrade | ternary('latest', 'enabled') }}"
   register: __nextcloud_app_installed
   retries: 3
-  delay: 3
+  delay: 15
   until: __nextcloud_app_installed is not failed
   with_items: "{{ nextcloud_apps }}"
 


### PR DESCRIPTION
Installing Nextcloud Apps regularly runs into:

  Connection failure: The read operation timed out

Maybe that's caused by rate-limits, which the Nextcloud Apps API might make use of.

Lets see if this naive approach introduced via this change works and makes these calls more reliable.