### PR TITLE
Notify push: introduce delays and retries

### DIFF
--- a/tasks/nextcloud/notify-push.yml
+++ b/tasks/nextcloud/notify-push.yml
@@ -48,6 +48,10 @@
       name: notify_push
       nextcloud_path: "{{ nextcloud_instance }}"
       state: "{{ nextcloud_apps_upgrade | ternary('latest', 'enabled') }}"
+    delay: 15
+    register: __nextcloud_app_notify_push_installed
+    retries: 3
+    until: __nextcloud_app_notify_push_installed is not failed
 
   - name: Run handlers (restart webserver) before notify_push tests
     ansible.builtin.meta: flush_handlers


### PR DESCRIPTION
This aims to address

  Connection failure: The read operation timed out

which this role regularly runs into.

For a recent similar change, see
182fd2f41651746791df4411c590bc602ab567ff and #100.