### PR TITLE
Add self-test option for Nextcloud notify_push configuration

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -160,6 +160,7 @@ nextcloud_notify_push_version: "latest"
 nextcloud_notify_push_url: "https://github.com/nextcloud/notify_push/releases/download/v{{ nextcloud_notify_push_version }}/notify_push-x86_64-unknown-linux-musl"
 nextcloud_notify_push_allow_self_signed: False
 nextcloud_notify_push_max_connection_time: False
+nextcloud_notify_push_self_test: True
 
 # Uncomment to bind Nextcloud notify_push daemon to localhost
 # nextcloud_notify_push_bind: 127.0.0.1

--- a/tasks/nextcloud/notify-push.yml
+++ b/tasks/nextcloud/notify-push.yml
@@ -64,3 +64,4 @@
       chdir: "{{ nextcloud_webroot }}"
     changed_when: False
     check_mode: no
+    when: nextcloud_notify_push_self_test | bool


### PR DESCRIPTION
This pull request introduces a new configuration option to control whether the Nextcloud notify_push self-test is executed, making the deployment more flexible. In some contexts, it can be useful to disable this self-test because you have a setup that overrides the X-Forwarded-For headers (e.g., you anonymize client IP addresses).