### PR TITLE
Add support for custom occ cronjobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,30 @@ nextcloud_upgrade: False
 nextcloud_instance: "{{ nextcloud_workdir }}/nextcloud"
 ```
 
+# Cronjobs
+
+The role automatically creates a cron job for Nextcloud background tasks
+(`cron.php`) and optionally for automatic app updates.
+
+In addition, you can define custom cron jobs for Nextcloud `occ` commands
+using the `nextcloud_cronjobs` variable. Each entry only requires the `name`
+and `job` fields. The `job` field should contain only the occ subcommand
+and its arguments (the role prepends `php .../occ` and appends `>/dev/null`
+automatically). Schedule fields (`minute`, `hour`, `weekday`, `day`, `month`)
+default to `*`. Each entry also supports a `state` field (`present` or
+`absent`, defaults to `present`).
+
+```yaml
+nextcloud_cronjobs:
+  - name: "Nextcloud preview pre-generation"
+    minute: "*/10"
+    job: "preview:pre-generate"
+  - name: "Nextcloud file scan"
+    minute: "0"
+    hour: "2"
+    job: "files:scan --all"
+```
+
 # Notification push daemon support
 
 When `nextcloud_notify_push` is enabled, the [Nextcloud notify_push

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -179,3 +179,15 @@ nextcloud_cleanup_versions_keep: 4
 # Configure automatic app updates via cron
 nextcloud_app_update_cronjob: True
 nextcloud_app_update_cronjob_weekday: "1,3,5"
+
+# Additional occ cronjobs
+# Example:
+# nextcloud_cronjobs:
+#   - name: "Nextcloud preview pre-generation"
+#     minute: "*/10"
+#     job: "preview:pre-generate"
+#   - name: "Nextcloud file scan"
+#     minute: "0"
+#     hour: "2"
+#     job: "files:scan --all"
+nextcloud_cronjobs: []

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -125,6 +125,23 @@
     - role:nextcloud:install
     - role:nextcloud:upgrade
 
+- name: Create Nextcloud occ cronjobs
+  ansible.builtin.cron:
+    name: "{{ item.name }}"
+    minute: "{{ item.minute | default('*') }}"
+    hour: "{{ item.hour | default('*') }}"
+    weekday: "{{ item.weekday | default('*') }}"
+    day: "{{ item.day | default('*') }}"
+    month: "{{ item.month | default('*') }}"
+    user: "{{ nextcloud_http_user }}"
+    job: "php {{ nextcloud_symlink }}/occ {{ item.job }} >/dev/null"
+    cron_file: nextcloud
+    state: "{{ item.state | default('present') }}"
+  loop: "{{ nextcloud_cronjobs }}"
+  tags:
+    - role:nextcloud
+    - role:nextcloud:cron
+
 - name: Create Nextcloud logrotate rule
   ansible.builtin.template:
     src: nextcloud/nextcloud.logrotate.j2


### PR DESCRIPTION
## Summary

- Add a new `nextcloud_cronjobs` variable (default: `[]`) that allows defining custom cron jobs for Nextcloud `occ` commands
- Each entry specifies a `name`, `job` (occ subcommand), optional schedule fields (`minute`, `hour`, `weekday`, `day`, `month`), and optional `state` (`present`/`absent`)
- The role automatically prepends `php .../occ` and appends `>/dev/null`, keeping configuration concise
- All cron entries are managed in the shared `/etc/cron.d/nextcloud` cron file, consistent with existing cron jobs

## Example usage

```yaml
nextcloud_cronjobs:
  - name: "Nextcloud preview pre-generation"
    minute: "*/10"
    job: "preview:pre-generate"
  - name: "Nextcloud file scan"
    minute: "0"
    hour: "2"
    job: "files:scan --all"
```

---
<sub>The changes and the PR were generated by OpenCode.</sub>