### PR TITLE
src: bugfix: download.yml: git add ownership and depth

### DIFF
--- a/tasks/nextcloud/download.yml
+++ b/tasks/nextcloud/download.yml
@@ -1,7 +1,8 @@
----
 - name: "Nextcloud download: create temporary download directory"
   ansible.builtin.file:
     name: "{{ nextcloud_dl_tmp_dir }}"
+    owner: root
+    group: root
     state: directory
     mode: 0755
 
@@ -10,6 +11,7 @@
     repo: "{{ nextcloud_repo }}"
     dest: "{{ nextcloud_dl_tmp_dir }}/nextcloud"
     version: "v{{ nextcloud_version }}"
+    depth: 1
   when: nextcloud_src_type == "git"
 
 - name: "Nextcloud download: Download Nextcloud archive"


### PR DESCRIPTION
the tasks inside download.yml change the ownership of the cloned repo dir.  if a playbook fails, this dir is not removed but also now the ownership is set to the user of the webserver.  a second run without manually removing or changing the ownership back to root will fail due to dubious ownership.

setting the clone depth to `1` will avoid to download the huge repo. this is unnecessary and may fail depending on the ram size of the machine.

also note: https://github.com/nextcloud/server/issues/36657.  i had a bad time try to updating via source `git`.. :finnadie: 

cheers and thx for this repo and your great services!